### PR TITLE
feat: remove out registration form and related UI elements in auth page

### DIFF
--- a/src/components/features/auth/login.tsx
+++ b/src/components/features/auth/login.tsx
@@ -159,14 +159,14 @@ const Login = () => {
 					</div>
 				</form>
 
-				<div className="mt-4 text-center text-sm text-gray-600 dark:text-gray-400">
+				{/* <div className="mt-4 text-center text-sm text-gray-600 dark:text-gray-400">
 					Don't have an account?{" "}
 					<Link
 						to="/register"
 						className="text-blue-600 hover:text-blue-500 dark:text-blue-400">
 						Sign up
 					</Link>
-				</div>
+				</div> */}
 				{/* <div className="mt-4 text-center text-sm text-gray-600 dark:text-gray-400">
 					Demo Credentials:
 					<br />

--- a/src/components/features/auth/login.tsx
+++ b/src/components/features/auth/login.tsx
@@ -4,7 +4,6 @@ import { School, User } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { APP_CONSTANTS } from "@/configs/app-constants";
 import { Button } from "@/components/ui/button";
-import { Link } from "react-router-dom";
 import { useAuth } from "@/contexts/auth-context";
 import { toast } from "sonner";
 import InputWithToggle from "@/components/ui/input-toggle";
@@ -141,13 +140,13 @@ const Login = () => {
 							</label> */}
 						</div>
 
-						<div className="text-sm">
+						{/* <div className="text-sm">
 							<Link
 								to="/forgot-password"
 								className="font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400">
 								Forgot your password?
 							</Link>
-						</div>
+						</div> */}
 					</div>
 
 					<div>

--- a/src/pages/auth-page.tsx
+++ b/src/pages/auth-page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { APP_CONSTANTS } from "@/configs/app-constants";
 import Login from "@/components/features/auth/login";
 import SplashScreen from "@/layouts/splash-screen";
-import RegistrationForm from "@/components/features/auth/registration-form";
 import { useAuth } from "@/contexts/auth-context";
 
 const AuthPage = () => {
@@ -64,7 +63,7 @@ const AuthPage = () => {
 					</>
 				) : (
 					<>
-						<RegistrationForm />
+						{/* <RegistrationForm /> */}
 						<section className="w-[70%] h-full hidden md:block">
 							<div
 								className="absolute inset-0 bg-gray-200 animate-pulse"


### PR DESCRIPTION
This pull request primarily involves commenting out sections of code related to the registration functionality in the authentication pages. These changes suggest that the registration feature is temporarily disabled or being refactored. Below is a summary of the most important changes grouped by theme.

### Changes to Registration Functionality:

* **Commented out the registration form import:**
  The `RegistrationForm` component import was commented out in `src/pages/auth-page.tsx`, indicating that the registration feature is no longer used on the authentication page.

* **Commented out the registration form component:**
  The `RegistrationForm` component was commented out in the JSX structure of `AuthPage`, effectively removing it from the rendered output.

* **Commented out the "Sign up" link:**
  The "Don't have an account? Sign up" link was commented out in the `Login` component, removing the option for users to navigate to the registration page.